### PR TITLE
Try fix dependabot branch names failing the branches-ignore filter

### DIFF
--- a/.github/workflows/uut-on-push-branches-ignore.yml
+++ b/.github/workflows/uut-on-push-branches-ignore.yml
@@ -5,12 +5,14 @@ on:
   push:
     branches-ignore:
     # anything other than "_some_other_fake_trunk_name"
+    # Or, at least, expect no legitimate branch to start with an underscore.
+    - 'fake_trunk'
+    - 'dependabot/**'
     # this test workflow will constantly need to have dev branch names added
     # here, otherwise it will fail on the PR test. just preface the whole thing
     # with every initial letter and expect no legit branch to start with _.
     # I realise now this is a fairly contrived test case but I've already built
     # for it so may as well just do it.
-    - 'fake_trunk'
     - 'a*'
     - 'b*'
     - 'c*'


### PR DESCRIPTION
Does adding a dependabot double-star filter in branches ignore let depednabot branch names pass it?

<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/Skenvy/dispatch-suggestor/blob/main/CONTRIBUTING.md
-->
# What issue is this addressing?
<!-- EITHER|OR of the two below -->
<!-- Fixes #<issue number> -->
<!-- Fixes (paste link of issue) -->
## What _type_ of issue is this addressing?
<!-- bug | enhancement | security -->
## What this PR does | solves
<!-- Please be as descriptive as possible -->
