### PR TITLE
Some ossf recommendations.

### DIFF
--- a/.github/workflows/action-test.yaml
+++ b/.github/workflows/action-test.yaml
@@ -4,12 +4,13 @@ on:
 defaults:
   run:
     shell: bash
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
+permissions: {}
 jobs:
   test:
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
     name: TEST -- ${{ matrix.job-name }}
     runs-on: 'ubuntu-latest'
     # What are we testing for here? Well the repo about is...
@@ -217,12 +218,13 @@ jobs:
     - name: Eval -- comment left by action is as-expected
       env:
         GH_TOKEN: ${{ github.token }}
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |-
         # Set un-star-globbing, and replace template vars in expected
         CONFIG_FILE=".github/workflows/config/uut-expected-comment-blocks.yml"
         set -f
         sed -i "s|{{ github.run_id }}|${{ github.run_id }}|g" "$CONFIG_FILE"
-        sed -i "s|{{ github.event.pull_request.head.ref }}|${{ github.event.pull_request.head.ref }}|g" "$CONFIG_FILE"
+        sed -i "s|{{ github.event.pull_request.head.ref }}|${{ env.HEAD_REF }}|g" "$CONFIG_FILE"
         # Get comment left by API
         contentsOfCommentFromApiFoundByUniqueIdentifier=\
         "$(gh api /repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/issues/${{ github.event.number }}/comments \

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,20 +1,16 @@
 name: GitHub 🐱‍👤 CodeQL 🛡👨‍💻🛡
 on:
   push:
-    paths:
-    - '**.js'
-    - '**.ts'
-    - '**.jsx'
-    - '**.tsx'
 defaults:
   run:
     shell: bash
-permissions:
-  actions: read
-  contents: read
-  security-events: write
+permissions: {}
 jobs:
   analyze:
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     name: Analyze
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,24 +1,25 @@
 name: Dispatch 📤 Suggestor 📥
 on:
   pull_request:
-permissions:
-  actions: read
-  contents: read
-  pull-requests: write
+permissions: {}
 jobs:
   suggestor:
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
     name: Dispatch 📤 Suggestor 📥
     runs-on: 'ubuntu-latest'
     steps:
     - name: 🏁 Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         sparse-checkout: |
           .github/workflows/*.y*ml
         sparse-checkout-cone-mode: false
     - name: Dispatch 📤 Suggestor 📥
       id: dispatch-suggestor
-      uses: Skenvy/dispatch-suggestor@v1
+      uses: Skenvy/dispatch-suggestor@eedaca42464a1d695fc5d46ee966d5dd1295fdb7 # v1.0.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: List changed files

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,10 +4,11 @@ on:
 defaults:
   run:
     shell: bash
-permissions:
-  contents: read
+permissions: {}
 jobs:
   test:
+    permissions:
+      contents: read
     name: Test List Verify
     runs-on: 'ubuntu-latest'
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -53,6 +53,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [dispatch-suggestor](https://github.com/Skenvy/dispatch-suggestor)
 [![Test](https://github.com/Skenvy/dispatch-suggestor/actions/workflows/main.yaml/badge.svg?branch=main&event=push)](https://github.com/Skenvy/dispatch-suggestor/actions/workflows/main.yaml)
 [![Action Tests](https://github.com/Skenvy/dispatch-suggestor/actions/workflows/action-test.yaml/badge.svg)](https://github.com/Skenvy/dispatch-suggestor/actions/workflows/action-test.yaml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Skenvy/dispatch-suggestor/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Skenvy/dispatch-suggestor)
 
 See it on the 🏪 [marketplace](https://github.com/marketplace/actions/dispatch-suggestor).
 


### PR DESCRIPTION
Add badge in readme, shuffle job permissions in workflows, pin 3 actions to shas, run ql on all pushes

<!--
Thanks for sending a pull request!
If this is your first time, please read the contributor guidelines:
https://github.com/Skenvy/dispatch-suggestor/blob/main/CONTRIBUTING.md
-->
# What issue is this addressing?
<!-- EITHER|OR of the two below -->
<!-- Fixes #<issue number> -->
<!-- Fixes (paste link of issue) -->
## What _type_ of issue is this addressing?
<!-- bug | enhancement | security -->
## What this PR does | solves
<!-- Please be as descriptive as possible -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to scope permissions at the job level for improved security.
  - Pinned GitHub Actions to specific commit SHAs for greater reliability.
  - Adjusted workflow triggers to run on all file changes, not just JavaScript/TypeScript files.

- **Documentation**
  - Added an OpenSSF Scorecard badge to the README for enhanced security transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->